### PR TITLE
Only include the files necessary to run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "typescript": "1.7.5",
     "rollup-pluginutils": "^1.1.0"
   },
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rollup/rollup-plugin-typescript.git"


### PR DESCRIPTION
v0.2.1 includes a bunch of files we don't want, some of which seem to be left over from previous versions:

```
node_modules/rollup-plugin-typescript/
├── CHANGELOG.md
├── README.md
├── dist
│   ├── index.js
│   └── index.js.map
├── index.js
├── package.json
├── src
│   └── index.js
├── test
│   ├── sample
│   │   ├── basic
│   │   │   └── main.ts
│   │   └── import-class
│   │       ├── A.js
│   │       ├── A.ts
│   │       ├── main.js
│   │       └── main.ts
│   └── test.js
└── tsconfig.json

6 directories, 14 files
```
