### PR TITLE
Include ts resolver and ScriptTarget to ES6

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,9 @@ module.exports = function ( options ) {
 			if(!importer) return null;
 			result = typescript.nodeModuleNameResolver(importee, importer, moduleResolutionHost);
 
-			if(result.resolvedModule && result.resolvedModule.resolvedFileName && result.resolvedModule.isExternalLibraryImport != true ) {
-				return result.resolvedModule.resolvedFileName;
+			if(result.resolvedModule && result.resolvedModule.resolvedFileName) {
+				fileName = result.resolvedModule.resolvedFileName.replace(/\.d\.ts$/, ".js");
+				return fileName;
 			} else {
 				return null;
 			}

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function ( options ) {
 
 			var transformed = typescript.transpileModule( code, {
 				compilerOptions: assign( {
-					target: typescript.ScriptTarget.ES5,
+					target: typescript.ScriptTarget.ES6,
 					module: typescript.ModuleKind.ES6,
 					sourceMap: true
 				}, options )


### PR DESCRIPTION
This PR will use typescript's resolver to find any extra files used in `import` statements utilising the node resolver.  This will enable transpiling & resolution in a more typescript fashion.

Also sets the target to `ES6` as that is what we should be targeting with rollup.js
