### PR TITLE
Handle TypeScript's `export class Name`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
   "dependencies": {
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.1.0",
+    "tippex": "^1.1.0",
     "typescript": "1.7.5"
   },
   "devDependencies": {
     "mocha": "^2.3.3",
     "rollup": "^0.25.0",
-    "rollup-plugin-typescript": "^0.2.0"
+    "rollup-plugin-typescript": "^0.3.0"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ export default {
 		'fs',
 		'object-assign',
 		'rollup-pluginutils',
+		'tippex',
 		'typescript'
 	],
 

--- a/src/fixExportClass.ts
+++ b/src/fixExportClass.ts
@@ -1,0 +1,70 @@
+import * as tippex from 'tippex';
+
+// Hack around TypeScript's broken handling of `export class` with
+// ES6 modules and ES5 script target.
+//
+// It works because TypeScript transforms
+//
+//     export class A {}
+//
+// into something like CommonJS, when we wanted ES6 modules.
+//
+//     var A = (function () {
+//         function A() {
+//         }
+//         return A;
+//     }());
+//     exports.A = A;
+//
+// But
+//
+//     class A {}
+//     export { A };
+//
+// is transformed into this beauty.
+//
+//     var A = (function () {
+//         function A() {
+//         }
+//         return A;
+//     }());
+//     export { A };
+//
+// The solution is to replace the previous export syntax with the latter.
+export default function fix ( code: string, id: string ): string {
+
+	// Erase comments, strings etc. to avoid erroneous matches for the Regex.
+	const cleanCode = tippex.erase( code );
+
+	const re = /export\s+(default\s+)?class(?:\s+(\w+))?/g;
+	let match;
+
+	while ( match = re.exec( cleanCode ) ) {
+		// To keep source maps intact, replace non-whitespace characters with spaces.
+		code = erase( code, match.index, match[ 0 ].indexOf( 'class' ) );
+
+		let name = match[ 2 ];
+
+		if ( match[ 1 ] ) { // it is a default export
+
+			// TODO: support this too 
+			if ( !name ) throw new Error( `TypeScript Plugin: cannot export an un-named class (module ${ id })` );
+
+			// Export the name ` as default`.
+			name += ' as default';
+		}
+
+		// To keep source maps intact, append the injected exports last.
+		code += `\nexport { ${ name } };`
+	}
+
+	return code;
+}
+
+function erase ( code: string, start: number, length: number ): string {
+	const end = start + length;
+
+	return code.slice( 0, start ) +
+		code.slice( start, end ).replace( /[^\s]/g, ' ' ) +
+		code.slice( end );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { createFilter } from 'rollup-pluginutils';
 import { statSync } from 'fs';
 import assign from 'object-assign';
 
+import fixExportClass from './fixExportClass';
+
 const resolveHost = {
 	fileExists ( filePath: string ): boolean {
 		try {
@@ -47,7 +49,8 @@ export default function typescript ( options ) {
 		transform ( code: string, id: string ): { code: string, map: any } {
 			if ( !filter( id ) ) return null;
 
-			const transformed = ts.transpileModule( code, {
+			const transformed = ts.transpileModule( fixExportClass( code, id ), {
+				fileName: id,
 				reportDiagnostics: true,
 				compilerOptions: options
 			});
@@ -61,7 +64,7 @@ export default function typescript ( options ) {
 				if ( diagnostic.file ) {
 					const { line, character } = diagnostic.file.getLineAndCharacterOfPosition( diagnostic.start );
 
-					console.error( `${diagnostic.file.fileName}(${line + 1},${character + 1}): error ES${diagnostic.code}: ${message}` );
+					console.error( `${diagnostic.file.fileName}(${line + 1},${character + 1}): error TS${diagnostic.code}: ${message}` );
 				} else {
 					console.error( `Error: ${message}` );
 				}

--- a/test/sample/export-class-fix/default.ts
+++ b/test/sample/export-class-fix/default.ts
@@ -1,0 +1,3 @@
+// the odd spacing is intentional
+export default
+		class A {}

--- a/test/sample/export-class-fix/main.ts
+++ b/test/sample/export-class-fix/main.ts
@@ -1,0 +1,4 @@
+import A from './default';
+import { B } from './named';
+
+export { A, B };

--- a/test/sample/export-class-fix/named.ts
+++ b/test/sample/export-class-fix/named.ts
@@ -1,0 +1,2 @@
+// the odd spacing is intentional
+export	class   B {}

--- a/test/sample/export-class/Foo.ts
+++ b/test/sample/export-class/Foo.ts
@@ -1,0 +1,3 @@
+export class Foo {
+    foo = 'bar';
+}

--- a/test/sample/export-class/main.ts
+++ b/test/sample/export-class/main.ts
@@ -1,3 +1,3 @@
 import {Foo} from './Foo.ts';
 
-new Foo();
+export default new Foo();

--- a/test/sample/export-class/main.ts
+++ b/test/sample/export-class/main.ts
@@ -1,0 +1,3 @@
+import {Foo} from './Foo.ts';
+
+new Foo();

--- a/test/test.js
+++ b/test/test.js
@@ -51,4 +51,27 @@ describe( 'rollup-plugin-typescript', function () {
 			assert.ok( code.indexOf( '=>' ) === -1, code );
 		});
 	});
+
+	it( 'should use named exports for classes', function () {
+		var start = Date.now();
+
+		return rollup.rollup({
+			entry: 'sample/export-class/main.ts',
+			plugins: [
+				typescript()
+			]
+		}).then( function ( bundle ) {
+			console.log( 'bundled in %s ms', Date.now() - start );
+
+			start = Date.now();
+			const generated = bundle.generate();
+			console.log( 'generated in %s ms', Date.now() - start );
+
+			const code = generated.code;
+
+			console.log(code);
+
+			assert.ok( code.indexOf( 'Foo' ) !== -1, code );
+		});
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,23 @@ describe( 'rollup-plugin-typescript', function () {
 		});
 	});
 
+	it( 'transpiles `export class A` correctly', function () {
+		return rollup.rollup({
+			entry: 'sample/export-class-fix/main.ts',
+			plugins: [
+				typescript()
+			]
+		}).then( function ( bundle ) {
+			const generated = bundle.generate();
+			const code = generated.code;
+
+			assert.equal( code.indexOf( 'class' ), -1, code );
+			assert.ok( code.indexOf( 'var A = (function' ) !== -1, code );
+			assert.ok( code.indexOf( 'var B = (function' ) !== -1, code );
+			assert.ok( code.indexOf( 'export { A, B };' ) !== -1, code );
+		});
+	});
+
 	it( 'transpiles ES6 features to ES5 with source maps', function () {
 		return rollup.rollup({
 			entry: 'sample/import-class/main.ts',
@@ -32,9 +49,9 @@ describe( 'rollup-plugin-typescript', function () {
 			const generated = bundle.generate();
 			const code = generated.code;
 
-			assert.ok( code.indexOf( 'class' ) === -1, code );
-			assert.ok( code.indexOf( '...' ) === -1, code );
-			assert.ok( code.indexOf( '=>' ) === -1, code );
+			assert.equal( code.indexOf( 'class' ), -1, code );
+			assert.equal( code.indexOf( '...' ), -1, code );
+			assert.equal( code.indexOf( '=>' ), -1, code );
 		});
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,15 @@ var typescript = require( '..' );
 
 process.chdir( __dirname );
 
+// Evaluate a bundle (as CommonJS) and return its exports.
+function evaluate( bundle ) {
+	const module = { exports: {} };
+
+	new Function( 'module', 'exports', bundle.generate({ format: 'cjs' }).code )(module, module.exports);
+
+	return module.exports;
+}
+
 describe( 'rollup-plugin-typescript', function () {
 	this.timeout( 5000 );
 
@@ -67,25 +76,13 @@ describe( 'rollup-plugin-typescript', function () {
 	});
 
 	it( 'should use named exports for classes', function () {
-		var start = Date.now();
-
 		return rollup.rollup({
 			entry: 'sample/export-class/main.ts',
 			plugins: [
 				typescript()
 			]
 		}).then( function ( bundle ) {
-			console.log( 'bundled in %s ms', Date.now() - start );
-
-			start = Date.now();
-			const generated = bundle.generate();
-			console.log( 'generated in %s ms', Date.now() - start );
-
-			const code = generated.code;
-
-			console.log(code);
-
-			assert.ok( code.indexOf( 'Foo' ) !== -1, code );
+			assert.equal( evaluate( bundle ).foo, 'bar' );
 		});
 	});
 });


### PR DESCRIPTION
Hack around TypeScript's broken handling of `export class` with ES6 modules and ES5 script target.

It works because TypeScript transforms

``` ts
export class A {}
```

into something like CommonJS, when we wanted ES6 modules.

``` js
var A = (function () {
    function A() {
    }
    return A;
}());
exports.A = A;
```

But

``` ts
class A {}
export { A };
```

is transformed into this beauty.

``` js
var A = (function () {
    function A() {
    }
    return A;
}());
export { A };
```

The solution is to replace the previous export syntax with the latter. The changes in this PR can be reverted once TypeScript supports this natively.

We also ensure that errors are reported for the current file.

Fixes #9
Includes #10
