### PR TITLE
Fix params of typescript.nodeModuleNameResolver to be compatible with TS 1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prebuild": "rm -rf dist/*"
   },
   "dependencies": {
+    "compare-versions": "2.0.1",
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.1.0",
     "tippex": "^1.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript';
 import { createFilter } from 'rollup-pluginutils';
 import { statSync } from 'fs';
 import assign from 'object-assign';
+import * as compareVersions from 'compare-versions';
 
 // This is loaded verbatim.
 import helpersTemplate from './typescript-helpers.ts';
@@ -66,7 +67,13 @@ export default function typescript ( options ) {
 
 			if ( !importer ) return null;
 
-			var result = typescript.nodeModuleNameResolver( importee, importer, resolveHost );
+			var result;
+
+			if ( compareVersions( typescript.version, '1.8.0' ) < 0 ) {
+				result = typescript.nodeModuleNameResolver( importee, importer, resolveHost );
+			} else {
+				result = typescript.nodeModuleNameResolver( importee, importer, {}, resolveHost );
+			}
 
 			if ( result.resolvedModule && result.resolvedModule.resolvedFileName ) {
 				if ( endsWith( result.resolvedModule.resolvedFileName, '.d.ts' ) ) {


### PR DESCRIPTION
See https://github.com/rollup/rollup-plugin-typescript/issues/31
