### PR TITLE
Add __assign helper

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ export default {
 
 	external: [
 		'compare-versions',
+		'path',
 		'fs',
 		'object-assign',
 		'rollup-pluginutils',

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ export default function typescript ( options: Options ) {
 			return {
 				// Always append an import for the helpers.
 				code: transformed.outputText +
-					`\nimport { __extends, __decorate, __metadata, __param, __awaiter } from 'typescript-helpers';`,
+					`\nimport { __assign, __awaiter, __extends, __decorate, __metadata, __param } from 'typescript-helpers';`,
 
 				// Rollup expects `map` to be an object so we must parse the string
 				map: JSON.parse(transformed.sourceMapText as string)

--- a/src/typescript-helpers.js
+++ b/src/typescript-helpers.js
@@ -1,3 +1,15 @@
+export const __assign = Object.assign || function (target) {
+    for (var source, i = 1; i < arguments.length; i++) {
+        source = arguments[i];
+        for (var prop in source) {
+            if (Object.prototype.hasOwnProperty.call(source, prop)) {
+                target[prop] = source[prop];
+            }
+        }
+    }
+    return target;
+};
+
 export function __extends(d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }

--- a/test/sample/assign/main.ts
+++ b/test/sample/assign/main.ts
@@ -1,0 +1,7 @@
+const others = {
+  b: 2,
+  c: 1,
+  d: 3
+};
+
+export default { a: 5, ...others, c: 3 };

--- a/test/sample/jsx/main.tsx
+++ b/test/sample/jsx/main.tsx
@@ -1,1 +1,1 @@
-export default <span>Yo!</span>
+export default <span {...props}>Yo!</span>

--- a/test/test.js
+++ b/test/test.js
@@ -100,28 +100,23 @@ describe( 'rollup-plugin-typescript', function () {
 	});
 
 	it( 'supports overriding the TypeScript version', function () {
-		return rollup.rollup({
-			entry: 'sample/overriding-typescript/main.ts',
-			plugins: [
-				typescript({
-					// Don't use `tsconfig.json`
-					tsconfig: false,
+		return bundle('sample/overriding-typescript/main.ts', {
+			// Don't use `tsconfig.json`
+			tsconfig: false,
 
-					// test with a mocked version of TypeScript
-					typescript: fakeTypescript({
-						version: '1.8.0-fake',
+			// test with a mocked version of TypeScript
+			typescript: fakeTypescript({
+				version: '1.8.0-fake',
 
-						transpileModule: function ( code ) {
-							// Ignore the code to transpile. Always return the same thing.
-							return {
-								outputText: 'export default 1337;',
-								diagnostics: [],
-								sourceMapText: JSON.stringify({ mappings: '' })
-							};
-						}
-					})
-				})
-			]
+				transpileModule: function ( code ) {
+					// Ignore the code to transpile. Always return the same thing.
+					return {
+						outputText: 'export default 1337;',
+						diagnostics: [],
+						sourceMapText: JSON.stringify({ mappings: '' })
+					};
+				}
+			})
 		}).then( function ( bundle ) {
 			assert.equal( evaluate( bundle ), 1337 );
 		});
@@ -184,7 +179,12 @@ describe( 'rollup-plugin-typescript', function () {
 		return bundle( 'sample/jsx/main.tsx', { jsx: 'react' }).then( function ( bundle ) {
 			const code = bundle.generate().code;
 
-			assert.ok( code.indexOf( 'React.createElement("span", null, "Yo!")' ) !== -1, code );
+			assert.notEqual( code.indexOf( 'const __assign = ' ), -1,
+				'should contain __assign definition' );
+
+			const usage = code.indexOf( 'React.createElement("span", __assign({}, props), "Yo!")' );
+
+			assert.notEqual( usage, -1, 'should contain usage' );
 		});
 	});
 


### PR DESCRIPTION
Add missing tests for __assign. One for usage as helper with React.createElement, and another one to be enabled when object spread is implemented.

Fixes #49
