### PR TITLE
move typescript to devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).
 ## Installation
 
 ```bash
-npm install --save-dev rollup-plugin-typescript
+npm install --save-dev rollup-plugin-typescript typescript
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rimraf": "^2.5.4",
     "rollup": "^0.34.3",
     "rollup-plugin-buble": "^0.13.0",
-    "typescript": "^2.0.8"
+    "typescript": "^2.1.4"
   },
   "peerDependencies": {
     "typescript": ">=1.8"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "compare-versions": "2.0.1",
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.3.1",
-    "tippex": "^2.1.1",
-    "typescript": "^1.8.9"
+    "tippex": "^2.1.1"
   },
   "devDependencies": {
     "buble": "^0.13.1",
@@ -39,7 +38,11 @@
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "rollup": "^0.34.3",
-    "rollup-plugin-buble": "^0.13.0"
+    "rollup-plugin-buble": "^0.13.0",
+    "typescript": "^2.0.8"
+  },
+  "peerDependencies": {
+    "typescript": ">=1.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Moving Typescript to devDependencies let the user decide which version of TS wants to use.

Also updated README.md for that.
