### PR TITLE
JSON parse source map only if it exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ export default function typescript ( options: Options ) {
 					`\nimport { __assign, __awaiter, __extends, __decorate, __metadata, __param } from 'typescript-helpers';`,
 
 				// Rollup expects `map` to be an object so we must parse the string
-				map: JSON.parse(transformed.sourceMapText as string)
+				map: transformed.sourceMapText ? JSON.parse(transformed.sourceMapText as string) : null
 			};
 		}
 	};

--- a/test/test.js
+++ b/test/test.js
@@ -201,6 +201,13 @@ describe( 'rollup-plugin-typescript', function () {
 			inlineSourceMap: true,
 		});
 	});
+
+	it ( 'should not fail if source maps are off', function () {
+		return bundle( 'sample/overriding-typescript/main.ts', {
+			inlineSourceMap: false,
+			sourceMap: false
+		});
+	});
 });
 
 function fakeTypescript( custom ) {


### PR DESCRIPTION
Now plugin fails when source maps are disabled because it doesn't check value being passed to JSON.parse
