### PR TITLE
fixExportClass conditions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,17 @@ export default function typescript ( options: Options ) {
 		transform ( code: string, id: string ): { code: string, map: any } {
 			if ( !filter( id ) ) return null;
 
-			const transformed = typescript.transpileModule( fixExportClass( code, id ), {
+			// Check that target is lower than ES6
+			if ( compilerOptions.target === undefined || compilerOptions.target < typescript.ScriptTarget.ES2015 ) {
+
+				// Typescript 2.0 supports target = ES5 and module = ES2015
+				const tsVersion = typescript.version.split('-')[0];
+				if ( compareVersions( tsVersion, '2.0.0' ) < 0 ) {
+					code = fixExportClass( code, id );
+				}
+			}
+
+			const transformed = typescript.transpileModule( code, {
 				fileName: id,
 				reportDiagnostics: true,
 				compilerOptions

--- a/test/sample/export-class-no-fix/main.ts
+++ b/test/sample/export-class-no-fix/main.ts
@@ -1,0 +1,1 @@
+export default class {}

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,16 @@ describe( 'rollup-plugin-typescript', function () {
 		});
 	});
 
+	it ( 'does not fix export class when targeting ES6', function () {
+		return bundle( 'sample/export-class-no-fix/main.ts', {
+			target: 'ES6'
+		}).then( function ( bundle ) {
+			const code = bundle.generate().code;
+
+			assert.ok( code.indexOf( 'export default main' ) !== -1, code );
+		});
+	});
+
 	it( 'transpiles ES6 features to ES5 with source maps', function () {
 		return bundle( 'sample/import-class/main.ts' ).then( function ( bundle ) {
 			const code = bundle.generate().code;
@@ -229,6 +239,14 @@ function fakeTypescript( custom ) {
 				options: options,
 				errors: []
 			};
+		},
+
+		ScriptTarget: {
+			ES3: 0,
+			ES5: 1,
+			ES6: 2,
+			ES2015: 2,
+			Latest: 2
 		}
 	}, custom);
 }


### PR DESCRIPTION
Now plugin always rewrites source code to support ES6 classes on ES5 target with old versions of typescript. Unfortunately, it adds some limitations.
This PR brings two checks when it should only be done:
- when compilerOptions.target is lower then ES2015
- when typescript has version lower then 2.0 (target=ES5 and module=ES2015 is supported in 2.0)
