### PR TITLE
Import separator fix in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "prebuild": "rimraf dist/*"
   },
   "dependencies": {
-    "compare-versions": "2.0.1",
+    "compare-versions": "2.0.2",
     "object-assign": "^4.0.1",
-    "rollup-pluginutils": "^1.3.1",
-    "tippex": "^2.1.1",
-    "typescript": "^1.8.9"
+    "rollup-pluginutils": "^1.5.1",
+    "tippex": "^2.2.0",
+    "typescript": "^1.8.10"
   },
   "devDependencies": {
-    "mocha": "^2.3.3",
+    "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "rollup": "^0.34.3",
     "rollup-plugin-typescript": "^0.7.7"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "devDependencies": {
     "mocha": "^2.3.3",
     "rimraf": "^2.5.4",
-    "rollup": "^0.25.7",
-    "rollup-plugin-typescript": "^0.5.0"
+    "rollup": "^0.34.3",
+    "rollup-plugin-typescript": "^0.7.7"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,10 @@ export default function typescript ( options: Options ) {
 			}
 
 			if ( !importer ) return null;
+			
+			if (path.sep !== "/") {
+				importer = importer.split(path.sep).join("/");
+			}
 
 			var result: ts.ResolvedModuleWithFailedLookupLocations;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ export default function typescript ( options: Options ) {
 			});
 
 			if ( fatalError ) {
-				throw new Error( `There were TypeScript errors transpiling "${id}"` );
+				throw new Error( `There were TypeScript errors.` );
 			}
 
 			return {

--- a/test/test.js
+++ b/test/test.js
@@ -82,7 +82,7 @@ describe( 'rollup-plugin-typescript', function () {
 
 	it( 'reports diagnostics and throws if errors occur during transpilation', function () {
 		return bundle( 'sample/syntax-error/missing-type.ts' ).catch( function ( error ) {
-			assert.ok( error.message.indexOf( 'There were TypeScript errors' ) === 0, 'Should reject erroneous code.' );
+			assert.ok( error.message.search( 'Error transforming') === 0 && error.message.search('There were TypeScript errors.' ) > -1, 'Should reject erroneous code.' );
 		});
 	});
 


### PR DESCRIPTION
Issue: https://github.com/rollup/rollup-plugin-typescript/issues/52

I try to debug at line [index.ts#L152](https://github.com/rollup/rollup-plugin-typescript/blob/master/src/index.ts#L152)

And that's happening because rollup function `resolveId` now gives `importer` param with OS path separators. 
Changed in [0.33.1](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0331) with this PR: https://github.com/rollup/rollup/pull/760

Before in Windows:

``` ts
importer = "D:/test/r/test/sample/overriding-typescript/main.ts"
```

Now in Windows:

``` ts
importer = "D:\\test\\r\\test\\sample\\overriding-typescript\\main.ts"
```

But Typescript `nodeModuleNameResolver` accept only with normal separator (`/`).
