### PR TITLE
Specify tsconfig.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.3.1",
     "tippex": "^2.1.1",
-    "typescript": "^2.1.4"
+    "typescript": "^1.8.9"
   },
   "devDependencies": {
     "buble": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.3.1",
     "tippex": "^2.1.1",
-    "typescript": "^1.8.9"
+    "typescript": "^2.1.4"
   },
   "devDependencies": {
     "buble": "^0.13.1",

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,11 @@ export default function typescript ( options ) {
 	delete options.typescript;
 
 	// Load options from `tsconfig.json` unless explicitly asked not to.
-	const tsconfig = options.tsconfig === false ? {} :
-		compilerOptionsFromTsConfig( typescript );
+	const tsconfig = options.tsconfig === false
+		? {}
+		: typeof options.tsconfig === 'string'
+			? compilerOptionsFromTsConfig(typescript, options.tsconfig)
+			: compilerOptionsFromTsConfig(typescript, 'tsconfig.json');
 
 	delete options.tsconfig;
 

--- a/src/options.js
+++ b/src/options.js
@@ -37,10 +37,10 @@ function findFile ( cwd, filename ) {
 	return null;
 }
 
-export function compilerOptionsFromTsConfig ( typescript ) {
+export function compilerOptionsFromTsConfig ( typescript, filename) {
 	const cwd = process.cwd();
 
-	const tsconfig = typescript.readConfigFile( findFile( cwd, 'tsconfig.json' ), path => readFileSync( path, 'utf8' ) );
+	const tsconfig = typescript.readConfigFile( findFile( cwd, filename ), path => readFileSync( path, 'utf8' ) );
 
 	if ( !tsconfig.config || !tsconfig.config.compilerOptions ) return {};
 

--- a/test/sample/custom-tsconfig/main.ts
+++ b/test/sample/custom-tsconfig/main.ts
@@ -1,0 +1,2 @@
+const answer: number = 42;
+console.log( `the answer is ${answer}` );

--- a/test/sample/custom-tsconfig/tsconfig.json
+++ b/test/sample/custom-tsconfig/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "target": "es6"
+    }
+}

--- a/test/sample/custom-tsconfig/tsconfig.json
+++ b/test/sample/custom-tsconfig/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": {
-        "target": "es6"
+        "target": "es6" 
     }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -220,6 +220,14 @@ describe( 'rollup-plugin-typescript', function () {
 			assert.ok( map.sources.every( source => source.indexOf( 'typescript-helpers' ) === -1) );
 		});
 	});
+
+	it( 'reads in custom tsconfig files', () => {
+		return bundle('sample/custom-tsconfig/main.ts', {
+			tsconfig: 'sample/custom-tsconfig/tsconfig.json'
+		}).then(bundle => {
+			assert.equal(bundle.modules[1].code.indexOf('const answer = 42'), 0);
+		});
+	});
 });
 
 function fakeTypescript ( custom ) {


### PR DESCRIPTION
Allows tsconfig path to be passed into the typescript options.  PR for #66 

``` javascript
{
    tsconfig: 'path/to/tsconfig.json'
}
```
