### PR TITLE
Don't use 'const' keyword in assign helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "6"
   - "4"
-  - "0.12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "4"
-    - nodejs_version: "0.12"
 
 version: "{build}"
 build: off

--- a/src/typescript-helpers.js
+++ b/src/typescript-helpers.js
@@ -1,4 +1,4 @@
-export const __assign = Object.assign || function (target) {
+export var __assign = Object.assign || function (target) {
     for (var source, i = 1; i < arguments.length; i++) {
         source = arguments[i];
         for (var prop in source) {

--- a/test/test.js
+++ b/test/test.js
@@ -179,7 +179,7 @@ describe( 'rollup-plugin-typescript', function () {
 		return bundle( 'sample/jsx/main.tsx', { jsx: 'react' }).then( bundle => {
 			const code = bundle.generate().code;
 
-			assert.notEqual( code.indexOf( 'const __assign = ' ), -1,
+			assert.notEqual( code.indexOf( 'var __assign = ' ), -1,
 				'should contain __assign definition' );
 
 			const usage = code.indexOf( 'React.createElement("span", __assign({}, props), "Yo!")' );


### PR DESCRIPTION
Currently when spread operator is used, there's `const` keyword in the generated code regardless what target is set. It causes errors in older browsers like e.g. Safari on iOS 8.