### PR TITLE
Fix: const keyword not transpiled on helpers

### DIFF
--- a/src/typescript-helpers.js
+++ b/src/typescript-helpers.js
@@ -1,4 +1,4 @@
-export const __assign = Object.assign || function (target) {
+export var __assign = Object.assign || function (target) {
     for (var source, i = 1; i < arguments.length; i++) {
         source = arguments[i];
         for (var prop in source) {


### PR DESCRIPTION
`const __assign` should be `var __assign`

This PR will fix following issue

```ts
// rollup.config.js
import typescript from 'rollup-plugin-typescript';
import ts from 'typescript';

export default {
    input: 'test.ts',
    output: {
        name: 'test',
        sourcemap: false,
        file: 'test.output.js',
        format: 'iife'
    },
    plugins: [
        typescript({
          typescript: ts
        })
    ]
};
```

```ts
// test.ts
const others = {
  b: 2,
  c: 1,
  d: 3,
};

export default {
  ...others,
};
```

```
// test.output.js
this.test = (function () {
'use strict';

const __assign = Object.assign || function (target) {
    for (var source, i = 1; i < arguments.length; i++) {
        source = arguments[i];
        for (var prop in source) {
            if (Object.prototype.hasOwnProperty.call(source, prop)) {
                target[prop] = source[prop];
            }
        }
    }
    return target;
};

var others = {
    b: 2,
    c: 1,
    d: 3
};
var test = __assign({}, others);

return test;

}());
```
