### PR TITLE
Support custom typescript plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.3.1",
     "tippex": "^2.1.1",
-    "typescript": "^1.8.9"
+    "typescript": "^2.6.2"
   },
   "devDependencies": {
     "buble": "^0.13.1",
@@ -39,7 +39,8 @@
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "rollup": "^0.49.3",
-    "rollup-plugin-buble": "^0.13.0"
+    "rollup-plugin-buble": "^0.13.0",
+    "ts-transform-safely": "0.0.4"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,9 @@ export default function typescript ( options ) {
 	adjustCompilerOptions( typescript, tsconfig );
 	adjustCompilerOptions( typescript, options );
 
+	const transformers = typeof options.getCustomTransformers === 'function' ? options.getCustomTransformers() : null;
+	delete options.getCustomTransformers;
+
 	// Merge all options.
 	options = assign( tsconfig, getDefaultOptions(), options );
 
@@ -108,11 +111,17 @@ export default function typescript ( options ) {
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
 
-			const transformed = typescript.transpileModule( fixExportClass( code, id ), {
+			const opts = {
 				fileName: id,
 				reportDiagnostics: true,
 				compilerOptions
-			});
+			};
+
+			if (transformers) {
+				opts.transformers = transformers;
+			}
+
+			const transformed = typescript.transpileModule( fixExportClass( code, id ), opts );
 
 			// All errors except `Cannot compile modules into 'es6' when targeting 'ES5' or lower.`
 			const diagnostics = transformed.diagnostics ?

--- a/src/options.js
+++ b/src/options.js
@@ -59,10 +59,19 @@ export function adjustCompilerOptions ( typescript, options ) {
 	// See: https://github.com/rollup/rollup-plugin-typescript/issues/45
 	delete options.declaration;
 
-	const tsVersion = typescript.version.split('-')[0];
-	if ( 'strictNullChecks' in options && compareVersions( tsVersion, '1.9.0' ) < 0 ) {
-		delete options.strictNullChecks;
+	const requiredVersions = {
+		strictNullChecks: '1.9.0',
+		getCustomTransformers: '2.3.0'
+	};
 
-		console.warn( `rollup-plugin-typescript: 'strictNullChecks' is not supported; disabling it` );
-	}
+	const tsVersion = typescript.version.split('-')[0];
+
+	Object.keys(requiredVersions).forEach((key) => {
+		const version = requiredVersions[key];
+		if (key in options && compareVersions( tsVersion, version ) < 0) {
+			delete options[key];
+
+			console.warn( `rollup-plugin-typescript: '${key}' is not supported with TypeScript < v${version}; disabling it` );
+		}
+	});
 }

--- a/test/sample/transformers/main.ts
+++ b/test/sample/transformers/main.ts
@@ -1,0 +1,17 @@
+export function getName(people, index) {
+  return get(people, [index, 'name'], 'Unknown');
+}
+
+export function getName_transformed(people, index) {
+  return people && people[index] && people[index]['name'] || 'Unknown';
+}
+
+export function getNameUndefined(people, index) {
+  const name = get(people, [index, 'name'], 'Unknown');
+  return name === 'Unknown' ? undefined : name;
+}
+
+export function getNameUndefined_transformed(people, index) {
+  const name = people && people[index] && people[index]['name'] || 'Unknown';
+  return name === 'Unknown' ? void 0 : name;
+}

--- a/test/sample/transformers/transformers.js
+++ b/test/sample/transformers/transformers.js
@@ -1,0 +1,49 @@
+const ts = require('typescript');
+
+const guardedAccess = (/* options */) => (context) => (sourceFile) => {
+	const visitor = (node) => {
+		if (ts.isCallExpression(node) &&
+			node.expression.getText(sourceFile) === 'get') {
+			const [obj, path, defaultValue] = node.arguments;
+			// check to make sure it is the expected argument types
+			if (ts.isArrayLiteralExpression(path)) {
+				// return a binary expression like a && a.b && a.b.c || defaultValue
+				return ts.createBinary(
+					// the gaurded access
+					path.elements.reduce((prev, elem) => [
+						...prev,
+						ts.createElementAccess(prev[prev.length - 1], ts.visitNode(elem, visitor))
+					], [obj]).reduce((prev, elem) => ts.createBinary(
+						prev,
+						ts.SyntaxKind.AmpersandAmpersandToken,
+						elem
+					)),
+					// the || operator
+					ts.SyntaxKind.BarBarToken,
+					defaultValue
+				);
+			}
+		}
+		// otherwise continue visiting all the nodes
+		return ts.visitEachChild(node, visitor, context);
+	};
+
+	return ts.visitNode(sourceFile, visitor);
+};
+
+const void0 = (/* options */) => (context) => (sourceFile) => {
+	const visitor = (node) => {
+		if (ts.isIdentifier(node) &&
+			node.getText(sourceFile) === 'undefined') {
+			// return `void 0` instead
+			return ts.createVoidZero();
+		}
+		// otherwise continue visiting all the nodes
+		return ts.visitEachChild(node, visitor, context);
+	};
+
+	return ts.visitNode(sourceFile, visitor);
+};
+
+exports.guardedAccess = guardedAccess;
+exports.void0 = void0;

--- a/test/sample/transformers/ts-loader-compat.ts
+++ b/test/sample/transformers/ts-loader-compat.ts
@@ -1,0 +1,1 @@
+safely(a.b);


### PR DESCRIPTION
- Support same schema as Webpack ts-loader
- Bumped default TS version to 2.6.2
- Will ignore option and provide a warning if TS version is too low
- Made other changes for DRY

The PR will remove Node v0.12 support. 