### PR TITLE
Add __read and __spread for ES5 downLevelIteration option

### DIFF
--- a/src/typescript-helpers.js
+++ b/src/typescript-helpers.js
@@ -39,3 +39,24 @@ export function __awaiter(thisArg, _arguments, P, generator) {
         step((generator = generator.apply(thisArg, _arguments)).next());
     });
 }
+
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
+var __spread = (this && this.__spread) || function () {
+    for (var ar = [], i = 0; i < arguments.length; i++) ar = ar.concat(__read(arguments[i]));
+    return ar;
+};


### PR DESCRIPTION
This is needed to get the full ES5 support for the Rollup TypeScript conversion, otherwise we will still be relying on native iterators.

This could possibly be behind a flag in the plugin, just let me know thoughts here.