### PR TITLE
Fix AppVeyor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "stable"
+  - "9"
+  - "8"
+  - "7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ build: off
 deploy: off
 
 install:
+  - node --version
+  - npm --version
   - npm install
 
 test_script:
-  - node --version
-  - npm --version
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,15 @@
 environment:
   matrix:
-    - nodejs_version: "stable"
+    - nodejs_version: "9"
+    - nodejs_version: "8"
+    - nodejs_version: "7"
 
 version: "{build}"
 build: off
 deploy: off
 
 install:
+  - ps: Install-Product node $env:nodejs_version
   - node --version
   - npm --version
   - npm install


### PR DESCRIPTION
Since `install` runs the tests, we need to print the node and npm versions before installing in case the tests fail.