### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install --save-dev rollup-plugin-typescript
 import typescript from 'rollup-plugin-typescript';
 
 export default {
-  entry: './main.ts',
+  input: './main.ts',
 
   plugins: [
     typescript()


### PR DESCRIPTION
As of Rollup 0.48 `entry` is now `input`. Reflect this in the readme.

https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32