### PR TITLE
WIP: Use user supplied TypeScript installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "compare-versions": "2.0.1",
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.3.1",
-    "tippex": "^2.1.1",
-    "typescript": "^1.8.9"
+    "tippex": "^2.1.1"
   },
   "devDependencies": {
     "buble": "^0.13.1",
@@ -39,7 +38,8 @@
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "rollup": "^0.49.3",
-    "rollup-plugin-buble": "^0.13.0"
+    "rollup-plugin-buble": "^0.13.0",
+    "typescript": "^2.8.3"
   },
   "repository": {
     "type": "git",
@@ -47,5 +47,8 @@
   },
   "bugs": {
     "url": "https://github.com/rollup/rollup-plugin-typescript/issues"
+  },
+  "peerDependencies": {
+    "typescript": "1.x || 2.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,21 +24,22 @@
     "pretest": "npm run build",
     "test": "mocha",
     "posttest": "npm run lint",
-    "prepublish": "npm run test"
+    "prepublishOnly": "npm run test"
   },
   "dependencies": {
-    "compare-versions": "2.0.1",
-    "object-assign": "^4.0.1",
-    "rollup-pluginutils": "^1.3.1",
-    "tippex": "^2.1.1"
+    "rollup-pluginutils": "^2.0.1",
+    "tippex": "^3.0.0"
   },
   "devDependencies": {
-    "buble": "^0.13.1",
-    "eslint": "^2.13.1",
-    "mocha": "^3.0.0",
+    "@types/node": "9.6.7",
+    "buble": "^0.19.3",
+    "eslint": "^4.19.1",
+    "mocha": "^5.1.1",
     "rimraf": "^2.5.4",
-    "rollup": "^0.49.3",
-    "rollup-plugin-buble": "^0.13.0",
+    "rollup": "^0.58.2",
+    "rollup-plugin-buble": "^0.19.2",
+    "rollup-plugin-node-resolve": "^3.3.0",
+    "tslib": "^1.9.0",
     "typescript": "^2.8.3"
   },
   "repository": {
@@ -49,6 +50,7 @@
     "url": "https://github.com/rollup/rollup-plugin-typescript/issues"
   },
   "peerDependencies": {
+    "tslib": "^1.9.0",
     "typescript": "1.x || 2.x"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,13 +5,12 @@ export default {
 	input: 'src/index.js',
 
 	external: [
-		'compare-versions',
 		'path',
 		'fs',
-		'object-assign',
 		'rollup-pluginutils',
 		'tippex',
-		'typescript'
+		'typescript',
+		'tslib'
 	],
 
 	plugins: [

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import compareVersions from 'compare-versions';
 import {
 	existsSync,
 	readFileSync
@@ -7,7 +6,6 @@ import {
 
 export function getDefaultOptions () {
 	return {
-		noEmitHelpers: true,
 		module: 'es2015',
 		sourceMap: true
 	};
@@ -59,10 +57,6 @@ export function adjustCompilerOptions ( typescript, options ) {
 	// See: https://github.com/rollup/rollup-plugin-typescript/issues/45
 	delete options.declaration;
 
-	const tsVersion = typescript.version.split('-')[0];
-	if ( 'strictNullChecks' in options && compareVersions( tsVersion, '1.9.0' ) < 0 ) {
-		delete options.strictNullChecks;
-
-		console.warn( `rollup-plugin-typescript: 'strictNullChecks' is not supported; disabling it` );
-	}
+	// Prevent duplication of helpers
+	options.importHelpers = true;
 }


### PR DESCRIPTION
Instead of shipping our own version of TypeScript we use the one supplied by the user via `peerDependencies`. I obviously need to break the commit apart and make the history a bit cleaner, but functionality-wise everything works as expected.

Changes:

- [x] use user supplied TS (let the user decide which version he/she wants to use)
- [x] use TS helpers instead of custom ones
- [x] don't force `es2015` target
- [x] remove `Object.assign` polyfill
- [x] upgrade dependencies
- [x] npm script `prepublish` -> `prepublishOnly`