### PR TITLE
chore: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - "9"
   - "8"
   - "7"
+before_install:
+  - npm i -g npm@latest
+install:
+  - npm ci 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,10 @@ deploy: off
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm i -g npm@latest
   - node --version
   - npm --version
-  - npm install
+  - npm ci
 
 test_script:
   - npm test


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable