### PR TITLE
Require typescript as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rimraf": "^2.5.4",
     "rollup": "^0.49.3",
     "rollup-plugin-buble": "^0.13.0",
-    "typescript": ">=1.8.9"
+    "typescript": "^1.8.9"
   },
   "peerDependencies": {
     "typescript": ">=1.8.9"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "compare-versions": "2.0.1",
     "object-assign": "^4.0.1",
     "rollup-pluginutils": "^1.3.1",
-    "tippex": "^2.1.1",
-    "typescript": "^1.8.9"
+    "tippex": "^2.1.1"
   },
   "devDependencies": {
     "buble": "^0.13.1",
@@ -40,6 +39,9 @@
     "rimraf": "^2.5.4",
     "rollup": "^0.49.3",
     "rollup-plugin-buble": "^0.13.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=1.8.9"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "rollup": "^0.49.3",
-    "rollup-plugin-buble": "^0.13.0"
+    "rollup-plugin-buble": "^0.13.0",
+    "typescript": ">=1.8.9"
   },
   "peerDependencies": {
     "typescript": ">=1.8.9"


### PR DESCRIPTION
Typescript is usually installed at the root for other stuff as well, so it does need to be a direct dependency of this plugin. Also fixes #116