### PR TITLE
Add index.d.ts typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,45 @@
+import { Plugin } from 'rollup';
+import { CompilerOptionsValue, TsConfigSourceFile } from 'typescript';
+
+interface RollupTypescriptOptions {
+    /**
+     * Determine which files are transpiled by Typescript (all `.ts` and
+     * `.tsx` files by default).
+     */
+    include?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+    /**
+     * Determine which files are transpiled by Typescript (all `.ts` and
+     * `.tsx` files by default).
+     */
+    exclude?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+    /**
+     * When set to false, ignores any options specified in the config file.
+     * If set to a string that corresponds to a file path, the specified file
+     * will be used as config file.
+     */
+    tsconfig?: string | false;
+    /**
+     * Overrides TypeScript used for transpilation
+     */
+    typescript?: typeof import('typescript');
+    /**
+     * Overrides the injected TypeScript helpers with a custom version
+     */
+    tslib?: typeof import('tslib');
+
+    /**
+     * Other Typescript compiler options
+     */
+    [option: string]:
+        | CompilerOptionsValue
+        | TsConfigSourceFile
+        | RollupTypescriptOptions['include']
+        | RollupTypescriptOptions['typescript']
+        | RollupTypescriptOptions['tslib']
+        | undefined;
+}
+
+/**
+ * Seamless integration between Rollup and Typescript.
+ */
+export default function typescript(options?: RollupTypescriptOptions): Plugin;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "jsnext:main": "dist/rollup-plugin-typescript.es.js",
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "keywords": [
     "rollup-plugin",
@@ -22,7 +23,7 @@
     "build": "rollup -c",
     "lint": "eslint src test/*.js",
     "pretest": "npm run build",
-    "test": "mocha",
+    "test": "mocha && tsc",
     "posttest": "npm run lint",
     "prepublishOnly": "npm run test",
     "prepare": "npm run build"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strict": true,
+        "noEmit": true,
+        "allowJs": true
+    },
+    "files": [
+        "index.d.ts",
+        "typings-test.js"
+    ]
+}

--- a/typings-test.js
+++ b/typings-test.js
@@ -1,0 +1,21 @@
+// @ts-check
+import typescript from '.';
+
+/** @type {import("rollup").RollupOptions} */
+const config = {
+    input: 'main.js',
+    output: {
+        file: 'bundle.js',
+        format: 'iife'
+    },
+    plugins: [
+        typescript({
+            lib: ["es5", "es6", "dom"],
+            target: "es5",
+            include: 'node_modules/**',
+            exclude: ['node_modules/foo/**', 'node_modules/bar/**', /node_modules/],
+        })
+    ]
+};
+
+export default config;


### PR DESCRIPTION
My continued efforts to fully support typechecking a Rollup config with TypeScript.

TypeScript allows for checking normal Javascript files by adding a `// @ts-check` comment at the top of the file. By providing typings users can check that they aren't passing misspelled or incorrect parameters, and see a hint about what each option does in their editor.

Fixes #137

---

Since the plugin accepts the same options as TypeScript's compiler options, I initially experimented with extending the exported `CompilerOptions` type. Unfortunately that interface doesn't match up with the JSON schema, and uses enums for certain values like `target`. I ended up just using an index type instead, although the types are slightly weaker. TypeScript just uses `any` for its JSON parsing function so this should be fine. 