### PR TITLE
Delete options.declarationMap

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -62,4 +62,9 @@ export function adjustCompilerOptions ( typescript, options ) {
 	// Delete the `declaration` option to prevent compilation error.
 	// See: https://github.com/rollup/rollup-plugin-typescript/issues/45
 	delete options.declaration;
+	// Delete the `declarationMap` option, as it will cause an error, unless
+	// composite is defined instead.
+	if(!options.composite) {
+		delete options.declarationMap;
+	}
 }

--- a/src/options.js
+++ b/src/options.js
@@ -62,9 +62,7 @@ export function adjustCompilerOptions ( typescript, options ) {
 	// Delete the `declaration` option to prevent compilation error.
 	// See: https://github.com/rollup/rollup-plugin-typescript/issues/45
 	delete options.declaration;
-	// Delete the `declarationMap` option, as it will cause an error, unless
-	// composite is defined instead.
-	if(!options.composite) {
-		delete options.declarationMap;
-	}
+	// Delete the `declarationMap` option, as it will cause an error, because we have
+	// deleted the `declaration` option.
+	delete options.declarationMap;
 }


### PR DESCRIPTION
We have a tsconfig file that defined 
```jsonc
{
  "compilerOptions": {
    "composite": true,
    "declaration": true,
    "declarationMap": true,
//...
}
```

I was very confused why I was getting an error like;
```

./src/index.ts → ./dist/index.js...
--
  | Error: Option 'declarationMap' cannot be specified without specifying option 'declaration' or option 'composite'.
  | [!] (typescript plugin) Error: There were TypeScript errors transpiling
  | src/index.ts


```

I then looked at the source code for this plugin, and saw that you were deleting `options.declaration` but not the declarationMap option