### PR TITLE
add support for tsconfig with "extends"

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -37,7 +37,7 @@ function findFile ( cwd, filename ) {
 	return null;
 }
 
-export function getCompilerOptionsFromTsConfig (typescript, tsconfigPath) {
+export function readTsConfig (typescript, tsconfigPath) {
 	if (tsconfigPath && !existsSync(tsconfigPath)) {
 		throw new Error(`Could not find specified tsconfig.json at ${tsconfigPath}`);
 	}
@@ -47,8 +47,8 @@ export function getCompilerOptionsFromTsConfig (typescript, tsconfigPath) {
 	}
 	const tsconfig = typescript.readConfigFile( existingTsConfig, path => readFileSync( path, 'utf8' ) );
 
-	if ( !tsconfig.config || !tsconfig.config.compilerOptions ) return {};
-	return tsconfig.config.compilerOptions;
+	if ( !tsconfig.config || !tsconfig.config.compilerOptions ) return { compilerOptions: {} };
+	return tsconfig.config;
 }
 
 export function adjustCompilerOptions ( typescript, options ) {

--- a/test/sample/tsconfig-extends/main.tsx
+++ b/test/sample/tsconfig-extends/main.tsx
@@ -1,0 +1,1 @@
+export default <span {...props}>Yo!</span>

--- a/test/sample/tsconfig-extends/tsconfig.base.json
+++ b/test/sample/tsconfig-extends/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/test/sample/tsconfig-extends/tsconfig.json
+++ b/test/sample/tsconfig-extends/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base",
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -180,6 +180,14 @@ describe( 'rollup-plugin-typescript', () => {
 		assert.notEqual( usage, -1, 'should contain usage' );
 	});
 
+	it( 'should support extends property in tsconfig', async () => {
+		process.chdir('sample/tsconfig-extends');
+		const code = await getCode( 'main.tsx');
+
+		const usage = code.indexOf( 'React.createElement("span", __assign({}, props), "Yo!")' );
+		assert.notEqual( usage, -1, 'should contain usage' );
+	});
+
 	it( 'allows specifying a path for tsconfig.json', async () => {
 		const code = await getCode( 'sample/tsconfig-jsx/main.tsx',
 			{tsconfig: path.resolve(__dirname, 'sample/tsconfig-jsx/tsconfig.json')});


### PR DESCRIPTION
> I know you're in the process of moving the repo, and I'd be glad to submit this PR to the new repo (when it's up), but I'd though I just give it a try anyway.

## Changes

When the original `tsconfig` file contains a "extends" property, use `typescript.parseJsonConfigFileContent` to parse the entire inheritance chain, providing the already parsed config as `existingOptions`.

## Tests

Added test where the base config is the one that has the `"jsx": "react"` required to make the test pass (copied the `tsconfig-jsx` test case)